### PR TITLE
Add main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/product-os/jellyfish-chat-widget.git"
   },
   "description": "Chat widget library for Jellyfish",
+  "main": "lib/index.jsx",
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add missing `main` directive to `package.json` pointing to `lib/index.jsx`.