### PR TITLE
Fix small mistake in Makefile, update filename lint script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,4 @@ lint:
 
 test: LOGLEVEL = warning
 test:
-	node $(NODE_DEBUG_ARGS) ./node_modules/.bin/ava $(AVA_ARGS) $(FILES) $(DOTENV_PATH)
+	node $(NODE_DEBUG_ARGS) ./node_modules/.bin/ava $(AVA_ARGS) $(FILES)

--- a/scripts/check-filenames.sh
+++ b/scripts/check-filenames.sh
@@ -8,7 +8,7 @@
 
 set -eu
 
-DIRECTORIES=(lib test scripts)
+DIRECTORIES=(test scripts)
 
 for file in $(find "${DIRECTORIES[@]}" -type f | grep -v -E node_modules); do
 	BASENAME="$(basename "$file")"
@@ -25,18 +25,6 @@ for file in $(find "${DIRECTORIES[@]}" -type f | grep -v -E node_modules); do
 
 	# JSX capitalized files are OK
 	if [[ $BASENAME =~ ^[A-Z].*\.jsx ]]; then
-		continue
-	fi
-
-	# TODO: This whole list of exceptions shouldn't exist as React
-	# components should only be defined in jellyfish-ui-components
-	COMPONENTS_DIRECTORIES="|lib/"
-
-	# We allow lowercase files inside React component directories
-	SUBPATH="$(echo "$file" | sed -E "s#^($COMPONENTS_DIRECTORIES)##g")"
-	SUBPATH_DIRNAME="$(dirname "$SUBPATH")"
-	SUBPATH_BASENAME="$(basename "$SUBPATH")"
-	if [[ $SUBPATH_DIRNAME =~ ^[A-Z] ]] && ! [[ $SUBPATH_BASENAME =~ [A-Z] ]]; then
 		continue
 	fi
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

- Remove reference to non-existent dotenv argument in Makefile
- Stop checking for uppercase filenames in lint