### PR TITLE
patch: Update jellyfish-ui-components dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,9 +1328,9 @@
       }
     },
     "@balena/jellyfish-ui-components": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-ui-components/-/jellyfish-ui-components-0.0.4.tgz",
-      "integrity": "sha512-hpolaVIM8fNfg5N2bXluNFbax1PU4ZY6MM7ffAxTSuXj81knEcVvhnfCFex/gqb5Wmg1sh7q7wDA64/mKkbiGQ==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-ui-components/-/jellyfish-ui-components-0.0.7.tgz",
+      "integrity": "sha512-Nzzit+2MWExY/EKIGBkKmqd8ydO46phWWaJ/SXwQ7DK3Adq0qp/ILrvYIR6gx7dUPU4lgU9kc4Ne6WbQf2SC+g==",
       "requires": {
         "@balena/jellyfish-client-sdk": "^2.1.0",
         "@sentry/browser": "^5.20.1",
@@ -1363,6 +1363,7 @@
         "react-select": "^3.1.0",
         "react-textarea-autosize": "^7.1.2",
         "react-visibility-sensor": "^5.1.1",
+        "redux": "^4.0.5",
         "rendition": "^16.2.0",
         "skhema": "^5.3.0",
         "styled-components": "^5.1.1",
@@ -6389,11 +6390,6 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
-    "lodash.concat": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.concat/-/lodash.concat-4.5.0.tgz",
-      "integrity": "sha1-sFOuAuSoAIWC5yVrnQK9ptA4A5U="
-    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -6406,31 +6402,17 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
-    "lodash.intersection": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
-      "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
-    },
     "lodash.islength": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
       "integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=",
       "dev": true
     },
-    "lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lodash.omit": {
       "version": "4.5.0",
@@ -6457,16 +6439,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
-    },
-    "lodash.union": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
-    },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "log-symbols": {
       "version": "3.0.0",
@@ -8644,9 +8616,9 @@
       }
     },
     "skhema": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.3.2.tgz",
-      "integrity": "sha512-UPUNXkdfh2FEuv6+HYJ+JzYMxzhabmmZ/Gn9cF+GmNNe7X6EpMAzVjaskrTUK5q5lLR4HJ9u20Sl+mGXBnY6Yw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.3.3.tgz",
+      "integrity": "sha512-jCfJnPSnZtT3zybzvX6ZuNiz0aHyTT84hcUG3tZi3nDXg0C1AI8JbZP+Kou8Cvsh782WWPnO6k4+xxDx7z0RQA==",
       "requires": {
         "@types/json-schema": "^6.0.1",
         "ajv": "^6.5.1",
@@ -8655,14 +8627,7 @@
         "fast-memoize": "^2.5.1",
         "json-schema-faker": "^0.5.0-rc16",
         "json-schema-merge-allof": "^0.6.0",
-        "lodash.concat": "^4.5.0",
-        "lodash.intersection": "^4.4.0",
-        "lodash.mapvalues": "^4.6.0",
-        "lodash.merge": "^4.6.1",
-        "lodash.mergewith": "^4.6.1",
-        "lodash.omit": "^4.5.0",
-        "lodash.union": "^4.6.0",
-        "lodash.uniq": "^4.5.0",
+        "lodash": "^4.17.19",
         "lru-cache": "^5.1.1",
         "typed-error": "^3.2.0"
       },
@@ -9397,9 +9362,9 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "typed-error": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/typed-error/-/typed-error-3.2.0.tgz",
-      "integrity": "sha512-n0NojMTp7jD2MMgJxtjzS1it/sKIlDfQwqOECSPAGwsIU2jns3G0R6alnakRelQzxz7t8PhjYrlqYoQKUVGOsQ=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/typed-error/-/typed-error-3.2.1.tgz",
+      "integrity": "sha512-XlUv4JMrT2dpN0c4Vm3lOm88ga21Z6pNJUmjejRz/mkh6sdBtkMwyRf4fF+yhRGZgfgWam31Lkxu11GINKiBTQ=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@balena/jellyfish-ui-components": "0.0.4",
+    "@balena/jellyfish-ui-components": "^0.0.7",
     "catch-uncommitted": "^1.6.2",
     "immutability-helper": "^3.1.1",
     "jsdoc-to-markdown": "^6.0.1",


### PR DESCRIPTION
Important - now using the caret to allow renovate to do this automatically.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>