### PR TITLE
Update chat widget to use the new streaming logic

### DIFF
--- a/lib/components/App.jsx
+++ b/lib/components/App.jsx
@@ -40,15 +40,48 @@ export const App = React.memo(({
 		environment
 	} = useSetup()
 
+	const	query = {
+		$$links: {
+			'has attached element': {
+				type: 'object',
+				additionalProperties: true
+			}
+		},
+		properties: {
+			links: {
+				type: 'object',
+				additionalProperties: true
+			},
+			type: {
+				const: 'support-thread@1.0.0'
+			},
+			active: {
+				const: true
+			},
+			data: {
+				properties: {
+					product: {
+						const: product
+					}
+				},
+				required: [
+					'product'
+				]
+			}
+		},
+		additionalProperties: true
+	}
+
 	const store = React.useMemo(() => {
 		return createStore({
 			product,
 			productTitle,
-			inbox
+			inbox,
+			query
 		}, {
 			environment
 		})
-	}, [ product, productTitle, inbox, environment ])
+	}, [ product, productTitle, inbox, query, environment ])
 
 	return (
 		<StoreProvider store={store}>

--- a/lib/hooks/use-stream.js
+++ b/lib/hooks/use-stream.js
@@ -18,9 +18,6 @@ import {
 	SET_CARDS
 } from '../store/action-types'
 import {
-	selectCardById
-} from '../store/selectors'
-import {
 	useTask
 } from './use-task'
 
@@ -29,21 +26,10 @@ const useSetupStreamFactory = () => {
 		sdk
 	} = useSetup()
 	const store = useStore()
+	const state = store.getState()
 
 	return React.useCallback(async () => {
-		const stream = await sdk.stream({
-			type: 'object',
-			properties: {
-				type: {
-					type: 'string',
-					enum: [
-						'message@1.0.0',
-						'support-thread@1.0.0'
-					]
-				}
-			},
-			required: [ 'type' ]
-		})
+		const stream = await sdk.stream(state.query)
 
 		stream.on('update', ({
 			data, error
@@ -53,41 +39,13 @@ const useSetupStreamFactory = () => {
 				return
 			}
 
-			// Ignore event that is neither insert nor update
-			const typeBase = data.type.split('@')[0]
-			if (typeBase !== 'insert' && typeBase !== 'update') {
-				return
-			}
-
-			const card = data.after
-
-			if (!card) {
-				return
-			}
-
-			const state = store.getState()
-
-			if (card.type.split('@')[0] === 'support-thread') {
-				// Only accept a thread with correct product type
-				if (card.data.product === state.product) {
-					store.dispatch({
-						type: SET_CARDS,
-						payload: [ card ]
-					})
-				}
-			} else if (card.type.split('@')[0] === 'message') {
-				// Accept a message only if it's corresponding thread is found in state
-				const thread = selectCardById(card.data.target)(state)
-
-				if (thread) {
-					store.dispatch({
-						type: SET_CARDS,
-						payload: [ card ]
-					})
-				}
+			if (data.type === 'update' || data.type === 'insert') {
+				store.dispatch({
+					type: SET_CARDS,
+					payload: [ data.after ]
+				})
 			}
 		})
-
 		return stream
 	}, [ sdk, store ])
 }

--- a/lib/store/action-creators.js
+++ b/lib/store/action-creators.js
@@ -94,7 +94,6 @@ export const fetchThread = (ctx) => {
 	return async (id) => {
 		const thread = await ctx.sdk.card.getWithTimeline(id)
 		setCards(ctx)([ thread ])
-		setCards(ctx)(thread.links['has attached element'])
 		return thread
 	}
 }
@@ -105,51 +104,29 @@ export const fetchThreads = (ctx) => {
 	}) => {
 		const state = ctx.store.getState()
 
-		const threads = await ctx.sdk.query(
-			{
-				$$links: {
-					'has attached element': {
-						type: 'object',
-						additionalProperties: true
-					}
-				},
-				properties: {
-					links: {
-						type: 'object',
-						additionalProperties: true
-					},
-					type: {
-						const: 'support-thread@1.0.0'
-					},
-					active: {
-						const: true
-					},
-					data: {
-						properties: {
-							product: {
-								const: state.product
-							}
-						},
-						required: [
-							'product'
-						]
-					}
-				},
-				additionalProperties: true
-			},
-			{
-				skip: selectThreads()(state).length,
-				limit,
-				sortBy: [ 'created_at' ],
-				sortDir: 'desc'
+		ctx.stream.emit('queryDataset', {
+			id: uuid(),
+			data: {
+				schema: state.query,
+				options: {
+					skip: selectThreads()(state).length,
+					limit,
+					sortBy: [ 'created_at' ],
+					sortDir: 'desc'
+				}
 			}
-		)
+		})
 
-		setCards(ctx)(
-			threads.reduce((cards, thread) => {
-				return cards.concat(thread, thread.links['has attached element'])
-			}, [])
-		)
+		return new Promise((resolve, reject) => {
+			ctx.stream.once('dataset', ({
+				data: {
+					cards
+				}
+			}) => {
+				setCards(ctx)(cards)
+				resolve()
+			})
+		})
 	}
 }
 

--- a/lib/store/reducer.js
+++ b/lib/store/reducer.js
@@ -18,25 +18,37 @@ const mergeCards = (state, cards) => {
 	}, state.cards)
 }
 
+const extractLinksFromCards = (threads) => {
+	return threads.reduce((cards, thread) => {
+		if (threads.links && threads.links['has attached element']) {
+			return cards.concat(thread, thread.links['has attached element'])
+		}
+		return cards.concat(thread)
+	}, [])
+}
+
 export const createReducer = ({
 	product,
 	productTitle,
-	inbox
+	inbox,
+	query
 }) => {
 	const initialState = {
 		product,
 		productTitle,
 		inbox,
 		cards: {},
-		currentUser: null
+		currentUser: null,
+		query
 	}
 
 	return (state = initialState, action) => {
 		switch (action.type) {
 			case SET_CARDS: {
+				const threads = extractLinksFromCards(action.payload)
 				return update(state, {
 					cards: {
-						$set: mergeCards(state, action.payload)
+						$set: mergeCards(state, threads)
 					}
 				})
 			}


### PR DESCRIPTION
Updates fetchThreads to emit a query on the stream instead of calling query on the sdk

**NOTE** since the chat-widget uses the timeline in ui-components, we may as well leave off merging this until the same stream updates have been merged and published. Then we can update ui-components as part of this PR