### PR TITLE
Fix typo preventing timeline from working. Remove unnecessary query for the thread

### DIFF
--- a/lib/routes/ChatRoute.jsx
+++ b/lib/routes/ChatRoute.jsx
@@ -40,14 +40,9 @@ export const ChatRoute = () => {
 	} = useSetup()
 	const router = useRouter()
 	const actions = useActions()
-	const fetchThreadTask = useTask(actions.fetchThread)
 	const currentUser = useSelector(selectCurrentUser())
 	const thread = useSelector(selectCardById(router.match.params.thread))
 	const messages = useSelector(selectMessages(router.match.params.thread))
-
-	React.useEffect(() => {
-		fetchThreadTask.exec(router.match.params.thread)
-	}, [])
 
 	// ToDo: implement this
 	const usersTyping = React.useMemo(() => {
@@ -65,52 +60,46 @@ export const ChatRoute = () => {
 	}, [ thread ])
 
 	return (
-		<Task task={fetchThreadTask}>
-			{() => {
-				return (
-					<Box
-						flex={1}
-						style={{
-							position: 'relative'
-						}}
-						data-test="chat-page"
-						data-test-id={thread.id}
-					>
-						<Box style={{
-							position: 'absolute',
-							width: '100%',
-							height: '100%'
-						}}>
-							<Timeline
-								selectCard={(id, type) => {
-									return (state) => {
-										return selectCardById(id)(state)
-									}
-								}}
-								getCard={actions.getCard}
-								enableAutocomplete={!environment.isTest()}
-								sdk={sdk}
-								types={types}
-
-								// TODO: #4229 add support for correctly identifying and formatting group mentions in the chat widget
-								groups={null}
-								wide={false}
-								allowWhispers={false}
-								card={thread}
-								tail={messages}
-								usersTyping={usersTyping}
-								user={currentUser}
-								getActor={actions.getActor}
-								addNotification={actions.addNotification}
-								signalTyping={_.noop}
-								setTimelineMessage={_.noop}
-								eventMenuOptions={false}
-								headerOptions={timelineHeaderOptions}
-							/>
-						</Box>
-					</Box>
-				)
+		<Box
+			flex={1}
+			style={{
+				position: 'relative'
 			}}
-		</Task>
+			data-test="chat-page"
+			data-test-id={thread.id}
+		>
+			<Box style={{
+				position: 'absolute',
+				width: '100%',
+				height: '100%'
+			}}>
+				<Timeline
+					selectCard={(id, type) => {
+						return (state) => {
+							return selectCardById(id)(state)
+						}
+					}}
+					getCard={actions.getCard}
+					enableAutocomplete={!environment.isTest()}
+					sdk={sdk}
+					types={types}
+
+					// TODO: #4229 add support for correctly identifying and formatting group mentions in the chat widget
+					groups={null}
+					wide={false}
+					allowWhispers={false}
+					card={thread}
+					tail={messages}
+					usersTyping={usersTyping}
+					user={currentUser}
+					getActor={actions.getActor}
+					addNotification={actions.addNotification}
+					signalTyping={_.noop}
+					setTimelineMessage={_.noop}
+					eventMenuOptions={false}
+					headerOptions={timelineHeaderOptions}
+				/>
+			</Box>
+		</Box>
 	)
 }

--- a/lib/store/action-creators.js
+++ b/lib/store/action-creators.js
@@ -90,14 +90,6 @@ export const initiateThread = (ctx) => {
 	}
 }
 
-export const fetchThread = (ctx) => {
-	return async (id) => {
-		const thread = await ctx.sdk.card.getWithTimeline(id)
-		setCards(ctx)([ thread ])
-		return thread
-	}
-}
-
 export const fetchThreads = (ctx) => {
 	return async ({
 		limit

--- a/lib/store/reducer.js
+++ b/lib/store/reducer.js
@@ -20,7 +20,7 @@ const mergeCards = (state, cards) => {
 
 const extractLinksFromCards = (threads) => {
 	return threads.reduce((cards, thread) => {
-		if (threads.links && threads.links['has attached element']) {
+		if (thread.links && thread.links['has attached element']) {
 			return cards.concat(thread, thread.links['has attached element'])
 		}
 		return cards.concat(thread)

--- a/lib/store/reducer.spec.js
+++ b/lib/store/reducer.spec.js
@@ -67,6 +67,7 @@ ava('SET_CARDS merges a card that\'s already in the state', (test) => {
 				links: {
 					'has attached element': [
 						{
+							id: '3',
 							slug: 'some-card'
 						}
 					]
@@ -89,13 +90,15 @@ ava('SET_CARDS merges a card that\'s already in the state', (test) => {
 				],
 				'has attached element': [
 					{
+						id: '3',
 						slug: 'some-card'
 					}
 				]
 			}
 		},
 		3: {
-			id: 3
+			id: 3,
+			slug: 'some-card'
 		},
 		2: {
 			id: 2


### PR DESCRIPTION
Two fixes:
- Fixes typo which was preventing us from storing the thread's messages in the state
- Removes unnecessary query for the thread (we can get this out of the state)