### PR TITLE
Use rendition notifications

### DIFF
--- a/lib/routes/ChatRoute.jsx
+++ b/lib/routes/ChatRoute.jsx
@@ -120,7 +120,6 @@ export const ChatRoute = () => {
 					usersTyping={usersTyping}
 					user={currentUser}
 					getActor={actions.getActor}
-					addNotification={actions.addNotification}
 					signalTyping={_.noop}
 					setTimelineMessage={_.noop}
 					eventMenuOptions={false}

--- a/lib/store/action-creators.js
+++ b/lib/store/action-creators.js
@@ -251,12 +251,6 @@ export const getActor = (ctx) => {
 	}
 }
 
-export const addNotification = () => {
-	return (...args) => {
-		console.log('addNotification', args)
-	}
-}
-
 export const getCard = (ctx) => {
 	// Type argument is included to keep this method signature
 	// the same as the corresponding Jellyfish action

--- a/package-lock.json
+++ b/package-lock.json
@@ -1296,9 +1296,9 @@
       }
     },
     "@balena/jellyfish-ui-components": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-ui-components/-/jellyfish-ui-components-1.2.13.tgz",
-      "integrity": "sha512-Z1A/6VSaN7H5/GTpAf8ALYzHq6Nog8crXL7UP+349WDbIcypwo6t+YjJQJZdQUGpWFMn9WQSFShaaqPZLj8loA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-ui-components/-/jellyfish-ui-components-2.0.0.tgz",
+      "integrity": "sha512-u2OkudsvwsImwjw4wfCwyMcf3g7uBp5GiSt68dPvcTuYvB1pIokhxGmQmD6/TtikSc05dUN7kmuwq9QkmKCXrA==",
       "requires": {
         "@balena/jellyfish-client-sdk": "^2.1.21",
         "@sentry/browser": "^5.24.2",
@@ -1335,6 +1335,79 @@
         "skhema": "^5.3.3",
         "styled-components": "^5.2.0",
         "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "rendition": {
+          "version": "18.9.1",
+          "resolved": "https://registry.npmjs.org/rendition/-/rendition-18.9.1.tgz",
+          "integrity": "sha512-T5z+ejSseK6EwSxQ3L8jV6P2ka7LjPr4g/0QRnlbFp3nRp2BwlI+/VRcX+X6NYA+Y2f5IXqduzD/XaKgPPNnvw==",
+          "requires": {
+            "@fortawesome/fontawesome-svg-core": "^1.2.25",
+            "@fortawesome/free-regular-svg-icons": "^5.11.2",
+            "@fortawesome/free-solid-svg-icons": "^5.11.2",
+            "@fortawesome/react-fontawesome": "^0.1.5",
+            "@mapbox/rehype-prism": "^0.5.0",
+            "@react-google-maps/api": "^1.9.7",
+            "@rjsf/core": "^2.2.1",
+            "@types/ajv-keywords": "^3.4.0",
+            "@types/color": "^3.0.0",
+            "@types/json-schema": "^7.0.5",
+            "@types/lodash": "^4.14.77",
+            "@types/node": "^13.13.4",
+            "@types/prop-types": "^15.7.0",
+            "@types/react-helmet": "^6.0.0",
+            "@types/recompose": "^0.26.2",
+            "@types/styled-components": "^5.0.1",
+            "@types/styled-system": "^4.0.0",
+            "@types/uuid": "^3.4.3",
+            "ajv": "^6.12.3",
+            "ajv-keywords": "^3.3.0",
+            "color": "^3.1.2",
+            "color-hash": "^1.0.3",
+            "copy-to-clipboard": "^3.0.8",
+            "date-fns": "^2.16.1",
+            "grommet": "^2.14.0",
+            "hast-util-sanitize": "^3.0.0",
+            "json-e": "^4.1.0",
+            "lodash": "^4.17.11",
+            "mermaid": "8.4.0",
+            "prismjs": "^1.21.0",
+            "prop-types": "^15.7.2",
+            "react-google-recaptcha": "^2.0.0-rc.1",
+            "react-helmet": "^6.0.0",
+            "react-monaco-editor": "^0.39.1",
+            "react-notifications-component": "^2.2.3",
+            "react-simplemde-editor": "^4.1.1",
+            "recompose": "0.26.0",
+            "regex-parser": "^2.2.7",
+            "regexp-match-indices": "^1.0.2",
+            "rehype-raw": "^4.0.2",
+            "rehype-react": "^6.1.0",
+            "rehype-sanitize": "^3.0.1",
+            "remark-parse": "^8.0.3",
+            "remark-rehype": "^7.0.0",
+            "resize-observer": "^1.0.0",
+            "styled-components": "^5.0.1",
+            "styled-system": "^4.1.0",
+            "tslib": "^2.0.0",
+            "unified": "^9.1.0",
+            "uuid": "^3.2.1",
+            "xterm": "^4.8.1",
+            "xterm-addon-fit": "^0.4.0"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
+          }
+        },
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+        }
       }
     },
     "@braintree/sanitize-url": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@balena/jellyfish-ui-components": "^1.2.13",
+    "@balena/jellyfish-ui-components": "^2.0.0",
     "catch-uncommitted": "^1.6.2",
     "immutability-helper": "^3.1.1",
     "jsdoc-to-markdown": "^6.0.1",


### PR DESCRIPTION
Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>

---

Note: the Rendition `NotificationsContainer` will be provided in the component tree in both the ui and livechat apps. No need for any explicit references to notifications in the chat widget code (at the moment).