### PR TITLE
Add groups to the redux of the chat widget - fixes bug with mentions not rendering

### DIFF
--- a/lib/components/Layout.jsx
+++ b/lib/components/Layout.jsx
@@ -43,6 +43,7 @@ export const Layout = ({
 	const actions = useActions()
 	const fetchThreads = useTask(actions.fetchThreads)
 	const setCurrentUser = useTask(actions.setCurrentUser)
+	const setGroups = useTask(actions.setGroups)
 	const combinedTask = useCombineTasks(fetchThreads, setCurrentUser)
 	const theme = useTheme()
 
@@ -52,6 +53,7 @@ export const Layout = ({
 		})
 
 		setCurrentUser.exec()
+		setGroups.exec()
 	}, [])
 
 	return (

--- a/lib/routes/ChatRoute.jsx
+++ b/lib/routes/ChatRoute.jsx
@@ -24,7 +24,8 @@ import {
 import {
 	selectCurrentUser,
 	selectMessages,
-	selectCardById
+	selectCardById,
+	selectGroups
 } from '../store/selectors'
 import {
 	FETCH_MORE_MESSAGES_LIMIT
@@ -41,6 +42,7 @@ export const ChatRoute = () => {
 	const router = useRouter()
 	const actions = useActions()
 	const currentUser = useSelector(selectCurrentUser())
+	const groups = useSelector(selectGroups())
 	const loadThreadDataTask = useTask(actions.loadThreadData)
 
 	const messages = useSelector(selectMessages(router.match.params.thread))
@@ -110,9 +112,7 @@ export const ChatRoute = () => {
 					enableAutocomplete={!environment.isTest()}
 					sdk={sdk}
 					types={types}
-
-					// TODO: #4229 add support for correctly identifying and formatting group mentions in the chat widget
-					groups={null}
+					groups={groups}
 					wide={false}
 					allowWhispers={false}
 					card={thread}

--- a/lib/store/action-creators.js
+++ b/lib/store/action-creators.js
@@ -14,13 +14,37 @@ import {
 } from '@balena/jellyfish-ui-components/lib/Timeline'
 import {
 	SET_CARDS,
-	SET_CURRENT_USER
+	SET_CURRENT_USER,
+	SET_GROUPS
 } from './action-types'
 import {
 	selectCardById,
 	selectCurrentUser,
 	selectThreads
 } from './selectors'
+
+const allGroupsWithUsersQuery = {
+	type: 'object',
+	description: 'Get all groups with member user slugs',
+	required: [ 'type', 'name' ],
+	$$links: {
+		'has group member': {
+			type: 'object',
+			required: [ 'slug' ],
+			properties: {
+				slug: {
+					type: 'string'
+				}
+			},
+			additionalProperties: false
+		}
+	},
+	properties: {
+		type: {
+			const: 'group@1.0.0'
+		}
+	}
+}
 
 //
 // Card exists here until it's loaded
@@ -173,6 +197,16 @@ export const setCurrentUser = (ctx) => {
 		ctx.store.dispatch({
 			type: SET_CURRENT_USER,
 			payload: currentUser
+		})
+	}
+}
+
+export const setGroups = (ctx) => {
+	return async () => {
+		const groups = await ctx.sdk.query(allGroupsWithUsersQuery)
+		ctx.store.dispatch({
+			type: SET_GROUPS,
+			payload: groups
 		})
 	}
 }

--- a/lib/store/action-types.js
+++ b/lib/store/action-types.js
@@ -6,3 +6,4 @@
 
 export const SET_CARDS = 'SET_CARDS'
 export const SET_CURRENT_USER = 'SET_CURRENT_USER'
+export const SET_GROUPS = 'SET_GROUPS'

--- a/lib/store/reducer.js
+++ b/lib/store/reducer.js
@@ -8,7 +8,8 @@ import _ from 'lodash'
 import update from 'immutability-helper'
 import {
 	SET_CARDS,
-	SET_CURRENT_USER
+	SET_CURRENT_USER,
+	SET_GROUPS
 } from './action-types'
 
 const mergeCards = (state, cards) => {
@@ -59,6 +60,12 @@ export const createReducer = ({
 					},
 					cards: {
 						$set: mergeCards(state, [ action.payload ])
+					}
+				})
+			case SET_GROUPS:
+				return update(state, {
+					groups: {
+						$set: action.payload
 					}
 				})
 

--- a/lib/store/selectors.js
+++ b/lib/store/selectors.js
@@ -20,6 +20,14 @@ export const selectCardById = (id) => {
 	}
 }
 
+export const selectGroups = () => {
+	return (state) => {
+		return {
+			groups: state.groups || []
+		}
+	}
+}
+
 export const selectThreads = () => {
 	return (state) => {
 		const threads = selectCardsByType('support-thread')(state)


### PR DESCRIPTION
This is a temporary fix to ensure messages with mentions still render in the chat widget. It's duplicated code from jellyfish so we should definitely clean up in future - or fix the mentions so groups is not a required field