### PR TITLE
Prevent ChatWidget creating multiple stores

### DIFF
--- a/lib/components/App.jsx
+++ b/lib/components/App.jsx
@@ -40,37 +40,39 @@ export const App = React.memo(({
 		environment
 	} = useSetup()
 
-	const	query = {
-		$$links: {
-			'has attached element': {
-				type: 'object',
-				additionalProperties: true
-			}
-		},
-		properties: {
-			links: {
-				type: 'object',
-				additionalProperties: true
+	const	query = React.useMemo(() => {
+		return {
+			$$links: {
+				'has attached element': {
+					type: 'object',
+					additionalProperties: true
+				}
 			},
-			type: {
-				const: 'support-thread@1.0.0'
-			},
-			active: {
-				const: true
-			},
-			data: {
-				properties: {
-					product: {
-						const: product
-					}
+			properties: {
+				links: {
+					type: 'object',
+					additionalProperties: true
 				},
-				required: [
-					'product'
-				]
-			}
-		},
-		additionalProperties: true
-	}
+				type: {
+					const: 'support-thread@1.0.0'
+				},
+				active: {
+					const: true
+				},
+				data: {
+					properties: {
+						product: {
+							const: product
+						}
+					},
+					required: [
+						'product'
+					]
+				}
+			},
+			additionalProperties: true
+		}
+	}, [ product ])
 
 	const store = React.useMemo(() => {
 		return createStore({


### PR DESCRIPTION
Previously it was creating a new one each time it was re-rendered!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes a bug that was introduced in [this commit](https://github.com/product-os/jellyfish-chat-widget/commit/e405fb272424ac6116b539857132cab2a9d8ec13). We need to prevent the Chat Widget creating a new instance of the store every time it is rendered. So we use a memo around the creation of the `query` variable.