### PR TITLE
Remove needless call to `uuid()`

### DIFF
--- a/lib/store/action-creators.js
+++ b/lib/store/action-creators.js
@@ -160,7 +160,6 @@ export const fetchThreads = (ctx) => {
 		const state = ctx.store.getState()
 
 		ctx.stream.emit('queryDataset', {
-			id: uuid(),
 			data: {
 				schema: state.query,
 				options: {


### PR DESCRIPTION
On a `queryDataset` even on a stream, the `id` is optional and in this case having one is useless.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>