### PR TITLE
Only load message contracts when querying timeline

### DIFF
--- a/lib/components/app.tsx
+++ b/lib/components/app.tsx
@@ -29,6 +29,11 @@ export const App = React.memo<any>(
 					'has attached element': {
 						type: 'object',
 						additionalProperties: true,
+						properties: {
+							type: {
+								const: 'message@1.0.0',
+							},
+						},
 					},
 				},
 				properties: {

--- a/lib/routes/chat-route.tsx
+++ b/lib/routes/chat-route.tsx
@@ -45,6 +45,11 @@ export const ChatRoute = () => {
 		$$links: {
 			'has attached element': {
 				type: 'object',
+				properties: {
+					type: {
+						const: 'message@1.0.0',
+					},
+				},
 			},
 		},
 		required: ['id'],


### PR DESCRIPTION
When using the chat widget, the only timeline contracts that are useful
are messages. We can simplify code by only querying for these contracts
instead of having to filter other types (create/update) at a later
point.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>