### PR TITLE
Support fetching an empty thread

### DIFF
--- a/lib/components/app.tsx
+++ b/lib/components/app.tsx
@@ -31,7 +31,7 @@ export const App = React.memo<any>(
 						additionalProperties: true,
 						properties: {
 							type: {
-								const: 'message@1.0.0',
+								enum: ['message@1.0.0', 'create@1.0.0'],
 							},
 						},
 					},

--- a/lib/routes/chat-route.tsx
+++ b/lib/routes/chat-route.tsx
@@ -47,7 +47,7 @@ export const ChatRoute = () => {
 				type: 'object',
 				properties: {
 					type: {
-						const: 'message@1.0.0',
+						enum: ['message@1.0.0', 'create@1.0.0'],
 					},
 				},
 			},


### PR DESCRIPTION
A recent change (https://github.com/product-os/jellyfish-chat-widget/pull/567) added a restriction that we should only fetch attached messages (with the intention of excluding whispers). But this inadvertently also excluded create cards - which the app relies on so that it can fetch a thread that doesn't yet have a message in it (i.e. before the user has typed a message).

This commit just ensures we fetch threads even if they just have a single create card (and no messages) attached to them.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>