### PR TITLE
Bump UI dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -732,9 +732,9 @@
       "dev": true
     },
     "@balena/jellyfish-client-sdk": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-5.0.4.tgz",
-      "integrity": "sha512-2RrEi5jNu4P5KE89t54jXkHNqNoiUINnEMneqqQMOjUTwKuodAIQvZx/KUfzivOGwZ/G9bEjjPKkOpZJVK8Dig==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-client-sdk/-/jellyfish-client-sdk-5.0.5.tgz",
+      "integrity": "sha512-3AGx8hv/ra/ym2Fg27UnUD4ejmh3jhunwdC3/5wTTptHczresQxBjvW3oSa9nCJBTVQCvczq+DbZbezgfFTqhw==",
       "dev": true,
       "requires": {
         "axios": "^0.21.1",
@@ -749,12 +749,11 @@
       }
     },
     "@balena/jellyfish-ui-components": {
-      "version": "9.2.34",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-ui-components/-/jellyfish-ui-components-9.2.34.tgz",
-      "integrity": "sha512-Qg100aHZtSbWwuyMEPNwOyFw7/UjALTg0zOM9DImP2otkDexWnqV7eFFiiPnnp0hUobvCWZDjRHZ14qzxuPSKA==",
+      "version": "9.2.37",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-ui-components/-/jellyfish-ui-components-9.2.37.tgz",
+      "integrity": "sha512-c6woz6UD9XnU/nGeALSLjYIUnAGdAPWclAbGuU4ZSx+C8l8ltwwlMA82FyQSM/IIjhT/ekfllmZJBDJVPahUWw==",
       "dev": true,
       "requires": {
-        "@balena/jellyfish-client-sdk": "^5.0.4",
         "@sentry/browser": "^6.7.1",
         "@webscopeio/react-textarea-autocomplete": "^4.7.3",
         "bluebird": "^3.7.2",
@@ -785,7 +784,7 @@
         "react-textarea-autosize": "^8.3.3",
         "react-visibility-sensor": "^5.1.1",
         "redux": "^4.1.0",
-        "rendition": "^20.17.2",
+        "rendition": "^20.18.0",
         "skhema": "^5.3.4",
         "styled-components": "^5.3.0",
         "uuid": "^8.3.2"
@@ -1982,65 +1981,65 @@
       }
     },
     "@sentry/browser": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.7.1.tgz",
-      "integrity": "sha512-R5PYx4TTvifcU790XkK6JVGwavKaXwycDU0MaAwfc4Vf7BLm5KCNJCsDySu1RPAap/017MVYf54p6dWvKiRviA==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.7.2.tgz",
+      "integrity": "sha512-Lv0Ne1QcesyGAhVcQDfQa3hDPR/MhPSDTMg3xFi+LxqztchVc4w/ynzR0wCZFb8KIHpTj5SpJHfxpDhXYMtS9g==",
       "dev": true,
       "requires": {
-        "@sentry/core": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
+        "@sentry/core": "6.7.2",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.7.1.tgz",
-      "integrity": "sha512-VAv8OR/7INn2JfiLcuop4hfDcyC7mfL9fdPndQEhlacjmw8gRrgXjR7qyhnCTgzFLkHI7V5bcdIzA83TRPYQpA==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.7.2.tgz",
+      "integrity": "sha512-NTZqwN5nR94yrXmSfekoPs1mIFuKvf8esdIW/DadwSKWAdLJwQTJY9xK/8PQv+SEzd7wiitPAx+mCw2By1xiNQ==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
+        "@sentry/hub": "6.7.2",
+        "@sentry/minimal": "6.7.2",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.7.1.tgz",
-      "integrity": "sha512-eVCTWvvcp6xa0A5GGNHMQEWslmKPlisE5rGmsV/kjvSUv3zSrI0eIDfb51ikdnCiBjHpK2NBWP8Vy8cZOEJegg==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.7.2.tgz",
+      "integrity": "sha512-05qVW6ymChJsXag4+fYCQokW3AcABIgcqrVYZUBf6GMU/Gbz5SJqpV7y1+njwWvnPZydMncP9LaDVpMKbE7UYQ==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.7.1.tgz",
-      "integrity": "sha512-HDDPEnQRD6hC0qaHdqqKDStcdE1KhkFh0RCtJNMCDn0zpav8Dj9AteF70x6kLSlliAJ/JFwi6AmQrLz+FxPexw==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.7.2.tgz",
+      "integrity": "sha512-jkpwFv2GFHoVl5vnK+9/Q+Ea8eVdbJ3hn3/Dqq9MOLFnVK7ED6MhdHKLT79puGSFj+85OuhM5m2Q44mIhyS5mw==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/types": "6.7.1",
+        "@sentry/hub": "6.7.2",
+        "@sentry/types": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.7.1.tgz",
-      "integrity": "sha512-9AO7HKoip2MBMNQJEd6+AKtjj2+q9Ze4ooWUdEvdOVSt5drg7BGpK221/p9JEOyJAZwEPEXdcMd3VAIMiOb4MA==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.7.2.tgz",
+      "integrity": "sha512-h21Go/PfstUN+ZV6SbwRSZVg9GXRJWdLfHoO5PSVb3TVEMckuxk8tAE57/u+UZDwX8wu+Xyon2TgsKpiWKxqUg==",
       "dev": true
     },
     "@sentry/utils": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.7.1.tgz",
-      "integrity": "sha512-Tq2otdbWlHAkctD+EWTYKkEx6BL1Qn3Z/imkO06/PvzpWvVhJWQ5qHAzz5XnwwqNHyV03KVzYB6znq1Bea9HuA==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.7.2.tgz",
+      "integrity": "sha512-9COL7aaBbe61Hp5BlArtXZ1o/cxli1NGONLPrVT4fMyeQFmLonhUiy77NdsW19XnvhvaA+2IoV5dg3dnFiF/og==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.7.1",
+        "@sentry/types": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
@@ -2655,7 +2654,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -3008,8 +3006,7 @@
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-      "dev": true
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "callsites": {
       "version": "3.1.0",
@@ -3191,9 +3188,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.61.1",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.1.tgz",
-      "integrity": "sha512-+D1NZjAucuzE93vJGbAaXzvoBHwp9nJZWWWF9utjv25+5AZUiah6CIlfb4ikG4MoDsFsCG8niiJH5++OO2LgIQ=="
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.0.tgz",
+      "integrity": "sha512-Xnl3304iCc8nyVZuRkzDVVwc794uc9QNX0UcPGeNic1fbzkSrO4l4GVXho9tRNKBgPYZXgocUqXyfIv3BILhCQ=="
     },
     "codemirror-spell-checker": {
       "version": "1.1.2",
@@ -3821,8 +3818,7 @@
     "deep-copy": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/deep-copy/-/deep-copy-1.4.2.tgz",
-      "integrity": "sha512-VxZwQ/1+WGQPl5nE67uLhh7OqdrmqI1OazrraO9Bbw/M8Bt6Mol/RxzDA6N6ZgRXpsG/W9PgUj8E1LHHBEq2GQ==",
-      "dev": true
+      "integrity": "sha512-VxZwQ/1+WGQPl5nE67uLhh7OqdrmqI1OazrraO9Bbw/M8Bt6Mol/RxzDA6N6ZgRXpsG/W9PgUj8E1LHHBEq2GQ=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -4009,8 +4005,7 @@
     "drange": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
-      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
-      "dev": true
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA=="
     },
     "easymde": {
       "version": "2.15.0",
@@ -4446,8 +4441,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esprima-walk": {
       "version": "0.1.0",
@@ -4675,8 +4669,7 @@
     "fast-memoize": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
-      "dev": true
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -4801,8 +4794,7 @@
     "format-util": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
-      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==",
-      "dev": true
+      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -8009,7 +8001,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -8081,7 +8072,6 @@
       "version": "0.5.0-rcv.34",
       "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rcv.34.tgz",
       "integrity": "sha512-Q68XN31eg8rtDNZQpW7f3BrOJxdpBFdPRTmvbn3rex0fI7hrQJGyoqEKb2lb5UiUS+sblOwgKq4aPtdzwHph9Q==",
-      "dev": true,
       "requires": {
         "json-schema-ref-parser": "^6.1.0",
         "jsonpath-plus": "^3.0.0",
@@ -8102,7 +8092,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
       "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-      "dev": true,
       "requires": {
         "call-me-maybe": "^1.0.1",
         "js-yaml": "^3.12.1",
@@ -8131,8 +8120,7 @@
     "jsonpath-plus": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-3.0.0.tgz",
-      "integrity": "sha512-WQwgWEBgn+SJU1tlDa/GiY5/ngRpa9yrSj8n4BYPHcwoxTDaMEaYCHMOn42hIHHDd3CrUoRr3+HpsK0hCKoxzA==",
-      "dev": true
+      "integrity": "sha512-WQwgWEBgn+SJU1tlDa/GiY5/ngRpa9yrSj8n4BYPHcwoxTDaMEaYCHMOn42hIHHDd3CrUoRr3+HpsK0hCKoxzA=="
     },
     "jsonpointer": {
       "version": "4.1.0",
@@ -8586,7 +8574,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "requires": {
         "yallist": "^3.0.2"
       }
@@ -9034,7 +9021,6 @@
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
       "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-      "dev": true,
       "requires": {
         "format-util": "^1.0.3"
       }
@@ -9466,9 +9452,9 @@
       }
     },
     "query-string": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.0.tgz",
-      "integrity": "sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
       "dev": true,
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -9489,7 +9475,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
       "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
-      "dev": true,
       "requires": {
         "drange": "^1.0.2",
         "ret": "^0.2.0"
@@ -9519,9 +9504,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.14.0.tgz",
-          "integrity": "sha512-3s+ed8er9ahK+zJpp9ZtuVcDoFzHNiZsPbNAAE4KXgrRHbjSqqNN6xGSXq6bq7TZIbKj4NLrLb6bJ5i+vSVjHA=="
+          "version": "3.15.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.0.tgz",
+          "integrity": "sha512-GUbtPllXMYRzIgHNZ4dTYTcUemls2cni83Q4Q/TrFONHfhcg9oEGOtaGHfb0cpzec60P96UKPvMkjX1jET8rUw=="
         }
       }
     },
@@ -9895,9 +9880,9 @@
       }
     },
     "rendition": {
-      "version": "20.17.2",
-      "resolved": "https://registry.npmjs.org/rendition/-/rendition-20.17.2.tgz",
-      "integrity": "sha512-EDruWECTBNCWEzh7yqK3m/iNvJ90+plcli8kshUxCfYlqnjmqc0E6mUZOB/kAckCS5rSTtpM65FtyV7BsQfe+A==",
+      "version": "20.18.0",
+      "resolved": "https://registry.npmjs.org/rendition/-/rendition-20.18.0.tgz",
+      "integrity": "sha512-y0gPT7CfDvSCyc9BusZPhqLmXpIgOz8TTYTQdPaDEXCsc1G4Q2NolEVGwqS1tcB+tjm9NjI8XZPrFL+AA01BWg==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-regular-svg-icons": "^5.15.3",
@@ -9947,6 +9932,7 @@
         "remark-parse": "^8.0.3",
         "remark-rehype": "^7.0.0",
         "resize-observer": "^1.0.0",
+        "skhema": "^5.3.4",
         "styled-components": "^5.2.1",
         "styled-system": "^4.1.0",
         "tslib": "^2.1.0",
@@ -10045,8 +10031,7 @@
     "ret": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
-      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
-      "dev": true
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -10266,7 +10251,6 @@
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/skhema/-/skhema-5.3.4.tgz",
       "integrity": "sha512-2xYL0EwAjqFfbr414RP/wKfM1fRd30kJAS2RsOA+UDq/vvszZeLXZWK9yTPYrr31rQzrczLMvLuD4z74EC3VBw==",
-      "dev": true,
       "requires": {
         "@types/json-schema": "^6.0.1",
         "ajv": "^6.5.1",
@@ -10283,8 +10267,7 @@
         "@types/json-schema": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-6.0.1.tgz",
-          "integrity": "sha512-vuL/tG01yKO//gmCmnV3OZhx2hs538t+7FpQq//sUV1sF6xiKi5V8F60dvAxe/HkC4+QaMCHqrm/akqlppTAkQ==",
-          "dev": true
+          "integrity": "sha512-vuL/tG01yKO//gmCmnV3OZhx2hs538t+7FpQq//sUV1sF6xiKi5V8F60dvAxe/HkC4+QaMCHqrm/akqlppTAkQ=="
         }
       }
     },
@@ -10395,8 +10378,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "stack-utils": {
       "version": "2.0.3",
@@ -10997,8 +10979,7 @@
     "typed-error": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/typed-error/-/typed-error-3.2.1.tgz",
-      "integrity": "sha512-XlUv4JMrT2dpN0c4Vm3lOm88ga21Z6pNJUmjejRz/mkh6sdBtkMwyRf4fF+yhRGZgfgWam31Lkxu11GINKiBTQ==",
-      "dev": true
+      "integrity": "sha512-XlUv4JMrT2dpN0c4Vm3lOm88ga21Z6pNJUmjejRz/mkh6sdBtkMwyRf4fF+yhRGZgfgWam31Lkxu11GINKiBTQ=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -11497,8 +11478,7 @@
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "peerDependencies": {
-    "@balena/jellyfish-ui-components": "^9.2.34"
+    "@balena/jellyfish-ui-components": "^9.2.37"
   },
   "dependencies": {
     "immutability-helper": "^3.1.1",
@@ -55,13 +55,14 @@
     "react-router-dom": "^5.2.0",
     "redux": "^4.1.0",
     "redux-thunk": "^2.3.0",
-    "rendition": "^20.17.2",
+    "rendition": "^20.18.0",
     "styled-components": "^5.3.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@balena/jellycheck": "^0.1.1",
-    "@balena/jellyfish-ui-components": "^9.2.34",
+    "@balena/jellyfish-client-sdk": "^5.0.5",
+    "@balena/jellyfish-ui-components": "^9.2.37",
     "@balena/lint": "^6.1.1",
     "@types/bluebird": "^3.5.35",
     "@types/jest": "^26.0.23",


### PR DESCRIPTION
Note - jellyfish-client-sdk needs to be explicitly added as a dev dependency as jellyfish-ui-components only references it as a peer dependency. Ugh.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>