### PR TITLE
Small fix to tsconfig settings

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "@balena/jellyfish-config/config/tsconfig.build.json",
   "compilerOptions": {
+    "target": "es2018",
     "jsx": "react"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "@balena/jellyfish-config/config/tsconfig.json",
   "compilerOptions": {
+    "target": "es2018",
     "jsx": "react"
-  },
-  "files": [
-    "./lib/index.tsx"
-  ]
+  }
 }


### PR DESCRIPTION
Webpack <5 does not support >ES2018 TypeScript so we restrict it here until we update to webpack 5!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>