### PR TITLE
Clone state inside reducer to ensure hooks update correctly

### DIFF
--- a/lib/store/reducer.ts
+++ b/lib/store/reducer.ts
@@ -15,10 +15,13 @@ import {
 } from './action-types';
 
 const mergeCards = (state, cards) => {
-	return cards.reduce((newCards, card) => {
-		newCards[card.id] = merge({}, newCards[card.id], card);
-		return newCards;
-	}, state.cards);
+	return Object.assign(
+		{},
+		cards.reduce((newCards, card) => {
+			newCards[card.id] = merge({}, newCards[card.id], card);
+			return newCards;
+		}, state.cards),
+	);
 };
 
 const extractLinksFromCards = (threads) => {


### PR DESCRIPTION
The current implementation of the reducer will mutate the existing state
object in some situations, resulting in the chat widget not updating
automatically, and only changing after a re-render happens.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>