### PR TITLE
Update to latest version of rendition

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
 	transform: {
 		'\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|css)$':
 		  '<rootDir>/file-transformer.js',
-	}
+	},
+	setupFiles: ['<rootDir>/test/setup.ts']
 };

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@balena/jellyfish-ui-components": "^13.1.21",
-    "rendition": "^21.12.7",
+    "@balena/jellyfish-ui-components": "^14.0.0",
+    "rendition": "^25.4.10",
     "styled-components": "^5.3.3"
   },
   "dependencies": {
@@ -62,7 +62,7 @@
     "@balena/jellyfish-client-sdk": "^7.0.36",
     "@balena/jellyfish-config": "^2.0.2",
     "@balena/jellyfish-types": "^1.2.42",
-    "@balena/jellyfish-ui-components": "^13.1.21",
+    "@balena/jellyfish-ui-components": "^14.0.0",
     "@balena/lint": "^6.2.0",
     "@types/jest": "^27.4.0",
     "@types/sinon": "^10.0.6",
@@ -71,7 +71,7 @@
     "eslint": "^8.6.0",
     "jest": "^27.4.7",
     "lint-staged": "^12.1.7",
-    "rendition": "^21.12.7",
+    "rendition": "^25.4.10",
     "simple-git-hooks": "^2.7.0",
     "sinon": "^12.0.1",
     "styled-components": "^5.3.3",

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,2 @@
+// @ts-ignore
+global.fetch = jest.fn(() => Promise.resolve());


### PR DESCRIPTION
This upgrade also means upgrading to the latest version of ui-components
that depends on v25.x of rendition.
The major changes in rendition do not affect this module, but since the
peer dependency has changed, this is a breaking change.

Change-type: major
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>